### PR TITLE
fixed setup.cfg for installing from source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,7 @@ dataframe. The library exposes one function—the ``edr_to_df``
 function—that gets the path to an EDR file and returns a pandas
 dataframe.
 
-``panedr`` is compatible with python 2.7 and greater, and with
-python 3.5 and greater.
+``panedr`` is compatible with python 3.6 and greater.
 
 Example
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 name = panedr
 author = Jonathan Barnoud
@@ -11,7 +8,7 @@ description_file =
     README.rst
 long_description_content_type = text/x-rst
 home_page = https://github.com/jbarnoud/panedr
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+python_requires = >=3.6
 classifier =
     Development Status :: 4 - Beta
     Intended Audience :: Developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ license = LGPL
 description_file =
     README.rst
 long_description_content_type = text/x-rst
-home_page = https://github.com/jbarnoud/panedr
+home_page = https://github.com/MDAnalysis/panedr
 python_requires = >=3.6
 classifier =
     Development Status :: 4 - Beta

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,15 +4,15 @@ universal=1
 [metadata]
 name = panedr
 author = Jonathan Barnoud
-author-email = jonathan@barnoud.net 
+author_email = jonathan@barnoud.net
 summary = Read and manipulate Gromacs energy files
 license = LGPL
-description-file =
+description_file =
     README.rst
 long_description_content_type = text/x-rst
-home-page = https://github.com/jbarnoud/panedr
-requires-python = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
-classifier = 
+home_page = https://github.com/jbarnoud/panedr
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+classifier =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
     Topic :: Scientific/Engineering :: Bio-Informatics


### PR DESCRIPTION
Addressing Issue #26 

setup.cfg had a problem in the following line:

> requires-python = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'

When trying to install from source with `pip install -e .` the following error was raised:

> error in setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: ''>=2.7'

This was because of the quotation marks around the version specifications. I have removed them in this PR, and `pip install -e .` now works properly. 

I have also changed a few hypens to underscores because dash-separation will not be supported in future versions of setuptools.  

I have not changed the python versions required/supported yet, is py38+ okay? Also, I am not sure if anything else needs to be changed/modernised because I am not too familiar with how all of this works.