### PR TITLE
Tie off v0.7.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,15 @@ The rules for this file:
   * Note: rules were not applied before v0.6.0
 
 ------------------------------------------------------------------------------
+02/09/2022 BFedder, IAlibay
+
+  * 0.7.0
+  
+  Changes
+  
+  * Add a new `get_unit_dictionary` method which returns a dictionary
+    with the units of each energy term found in the EDR file (PR #56)
+
 
 15/06/2022 jbarnoud, BFedder, orbeckst, hmacdope, IAlibay
 
@@ -30,6 +39,7 @@ The rules for this file:
   Fixes
 
   * Fix coverage issues and add coveragerc (PR #47)
+
 
 13/01/2019 jbarnoud
 


### PR DESCRIPTION
As per #53 we'll make 0.7.0 a reasonably short single feature release so we can get @BFedder's GSoC project moving along.

Fixes so that test files can be included in the distributed package (#54 and #55) will be done after this release is deployed, with a target 0.7.1 release.