### PR TITLE
Add py3.11, add codecov token

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v3
@@ -83,6 +83,7 @@ jobs:
     - name: codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
         fail_ci_if_error: True
         verbose: True

--- a/panedr/panedr/tests/test_edr.py
+++ b/panedr/panedr/tests/test_edr.py
@@ -5,7 +5,6 @@ Tests for panedr
 """
 
 import sys
-import unittest
 import pytest
 import contextlib
 import re
@@ -156,7 +155,3 @@ class TestEdrToDf(object):
         array_df = pandas.DataFrame.from_dict(edr.edr_dict).set_index(
                 "Time", drop=False)
         assert array_df.equals(edr.df)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/panedr/setup.cfg
+++ b/panedr/setup.cfg
@@ -21,6 +21,7 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
 
 [options]

--- a/pyedr/pyedr/tests/test_edr.py
+++ b/pyedr/pyedr/tests/test_edr.py
@@ -9,7 +9,6 @@ from io import StringIO
 from pathlib import Path
 import re
 import sys
-import unittest
 import pickle
 
 import pytest
@@ -212,6 +211,3 @@ def redirect_stderr(target):
     finally:
         sys.stderr = stderr
 
-
-if __name__ == '__main__':
-    unittest.main()

--- a/pyedr/pyedr/tests/test_edr.py
+++ b/pyedr/pyedr/tests/test_edr.py
@@ -210,4 +210,3 @@ def redirect_stderr(target):
         yield
     finally:
         sys.stderr = stderr
-

--- a/pyedr/setup.cfg
+++ b/pyedr/setup.cfg
@@ -21,6 +21,7 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
Add py3.11 "support" (would have worked either way).

Also adds a `token` entry to codecov (I really don't like that we have to do this, but I have to reluctantly agree that it fixes things...)