### PR TITLE
Don't run codecov on cron jobs

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -85,6 +85,7 @@ jobs:
         python -Ic "from panedr import edr_to_df"
 
     - name: codecov
+      if: ${{ github.event_name != 'schedule' }}
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Our Cron CI has been failing for the last month, turns out we just hit a limit on how many times you can push to codecov on a single commit. This will just avoid that problem altogether (we don't need to send coverage on a scheduled job).