### PR TITLE
Switch from deprecated xdrlib to mda-xdrlib

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,15 @@ The rules for this file:
   * Note: rules were not applied before v0.6.0
 
 ------------------------------------------------------------------------------
+??/??/???? IAlibay
+
+  * 0.8.0
+
+  Changes
+
+  * The mda-xdrlib library is now used instead of the deprecated xdrlib
+    Python library (PR #67)
+
 12/15/2022 BFedder, IAlibay
 
   * 0.7.1

--- a/pyedr/pyedr/pyedr.py
+++ b/pyedr/pyedr/pyedr.py
@@ -41,7 +41,7 @@ The library exposes the following functions:
 
 .. autofunction:: edr_to_dict
 """
-import xdrlib
+from mda_xdrlib import xdrlib
 import collections
 import warnings
 import sys

--- a/pyedr/requirements.txt
+++ b/pyedr/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.19.0
 pbr
 tqdm
+mda-xdrlib

--- a/pyedr/setup.cfg
+++ b/pyedr/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     numpy
     pbr
     tqdm
+    mda-xdrlib
 
 [options.extras_require]
 test =


### PR DESCRIPTION
XDRLIB is going away in Python 3.13, this replaces things with our own vendored package of that small part of the core library (mda-xdrlib).