### PR TITLE
Update changelog for 0.8.0 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ The rules for this file:
   * Note: rules were not applied before v0.6.0
 
 ------------------------------------------------------------------------------
-??/??/???? ezavod
+12/23/2023 ezavod, IAlibay
 
   * 0.8.0
 
@@ -22,6 +22,7 @@ The rules for this file:
 
   * Added support for legacy file version 1 (PR #22)
   * Extended test coverage and code cleanup (PR #22)
+  * Add support for Python 3.12 (PR #71 and #74)
 
 09/04/2023 IAlibay
 


### PR DESCRIPTION
It's time we cut a new release of pyedr and panedr to reflect the newly introduced changes in #22 and also to ensure we have proper Py3.12 support #74 